### PR TITLE
Download Service MinSDK

### DIFF
--- a/constants.gradle
+++ b/constants.gradle
@@ -16,14 +16,14 @@ project.ext {
  releaseVersion = '2.19.1'
  releaseVersionCode = 2_019_001
     minSdkVersion = 16
-    appTargetSdkVersion = 33
+    appTargetSdkVersion = 34
     // API version before restricting local file access.
     // https://developer.android.com/training/data-storage/app-specific
     mainDemoAppTargetSdkVersion = 29
     // Upgrading this requires [Internal ref: b/193254928] to be fixed, or some
     // additional robolectric config.
     targetSdkVersion = 30
-    compileSdkVersion = 33
+    compileSdkVersion = 34
     dexmakerVersion = '2.28.3'
     junitVersion = '4.13.2'
     // Use the same Guava version as the Android repo:

--- a/library/core/src/main/java/com/google/android/exoplayer2/offline/DownloadService.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/offline/DownloadService.java
@@ -22,6 +22,8 @@ import android.app.NotificationManager;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ServiceInfo;
+import android.os.Build;
 import android.os.Handler;
 import android.os.IBinder;
 import android.os.Looper;
@@ -922,7 +924,11 @@ public abstract class DownloadService extends Service {
       @RequirementFlags int notMetRequirements = downloadManager.getNotMetRequirements();
       Notification notification = getForegroundNotification(downloads, notMetRequirements);
       if (!notificationDisplayed) {
-        startForeground(notificationId, notification);
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+          startForeground(notificationId, notification);
+        } else {
+          startForeground(notificationId, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC);
+        }
         notificationDisplayed = true;
       } else {
         // Update the notification via NotificationManager rather than by repeatedly calling


### PR DESCRIPTION
Covers for a deprecated part not yet addressing level SDK 34.

This is meant to be a temporary solution to buy time for more permanent ones.

## ExoPlayer v2 is deprecated

This project is deprecated. The ExoPlayer code has moved to the
`androidx.media3` package and is published at
https://github.com/androidx/media. Please send any PRs to that project,
targeting the media3 `main` branch.

PRs on this project will be closed with no further comment.

